### PR TITLE
Fix typo in finnish translation

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 # alpine version should match the version in .nvmrc as closely as possible
-FROM node:12.19.1-alpine@sha256:sha256:c8b5faa496b3eaaaee30e278abee431ec7dfec03e07ca0fc6ee39e31f36e5021
+FROM node:12.19.1-alpine@sha256:c8b5faa496b3eaaaee30e278abee431ec7dfec03e07ca0fc6ee39e31f36e5021
 
 ARG env
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -2450,7 +2450,7 @@ msgid "Fixed value info"
 msgstr "Ennaltamääritelty pakollinen arvo joka täytyy löytyä datasta"
 
 msgid "Pattern"
-msgstr "Säännollinen lauseke"
+msgstr "Säännöllinen lauseke"
 
 msgid "Pattern info"
 msgstr ""


### PR DESCRIPTION
This PR fixes a simple typo in Finnish translation for "Pattern".

Additionally fixes the FROM instruction in `Dockerfile.local`.