### PR TITLE
YTI-1294 Fix json framing for history data

### DIFF
--- a/src/app/entities/frames.ts
+++ b/src/app/entities/frames.ts
@@ -179,21 +179,23 @@ export function modelFrame(data: any, options: { id?: Uri|Urn, prefix?: string }
     }
   };
 
-  const org = data['@graph'].find((o:any) => o['@type'] === 'foaf:Organization');
+  if (Array.isArray(data['@graph'])) {
+    const org = data['@graph'].find((o:any) => o['@type'] === 'foaf:Organization');
 
-  // For old data parentOrganization is undefined. Need to check for framing if present
-  if (org && typeof org.parentOrganization !== 'undefined') {
-    Object.assign(frameObj, {
-      contributor: {
-        '@omitDefault': true,
-        '@default': [],
-        parentOrganization: {
+    // For old data parentOrganization is undefined. Need to check for framing if present
+    if (org && typeof org.parentOrganization !== 'undefined') {
+      Object.assign(frameObj, {
+        contributor: {
           '@omitDefault': true,
           '@default': [],
-          '@embed': '@always'
+          parentOrganization: {
+            '@omitDefault': true,
+            '@default': [],
+            '@embed': '@always'
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   if (options.id) {

--- a/src/app/entities/frames.ts
+++ b/src/app/entities/frames.ts
@@ -197,7 +197,11 @@ export function modelFrame(data: any, options: { id?: Uri|Urn, prefix?: string }
   }
 
   if (options.id) {
-    Object.assign(frameObj, { 'dcterms:identifier': options.id.toString() });
+    const id = options.id.toString();
+    const provEntity = data['@graph'].find((d:any) => id === d.identifier);
+    if (provEntity) {
+      Object.assign(frameObj, { '@id': provEntity['@id'] });
+    }
   } else if (options.prefix) {
     Object.assign(frameObj, { preferredXMLNamespacePrefix: options.prefix });
   }


### PR DESCRIPTION
Previously objects were matched by `dcterms:identifier` property, which caused that CodeScheme objects were added to main level with datamodels. Change that objects are matched by `@id`

https://www.w3.org/TR/json-ld11-framing/#matching-on-id

Also fixed a bug related to YTI-1592: `@graph` is not always an array